### PR TITLE
Use older version of urllib3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,9 @@ poetry==1.7.1
 poetry-plugin-export==1.6.0
 poetry-dynamic-versioning==1.2.0
 poetry-plugin-tweak-dependencies-version==1.5.2
-pip==23.3.2
 poetry-plugin-drop-python-upper-constraint==0.1.0
+pip==23.3.2
+urllib3==1.26.18
 certifi>=2023.7.22 # not directly required, pinned by Snyk to avoid a vulnerability
 jinja2>=3.1.3 # not directly required, pinned by Snyk to avoid a vulnerability
 idna>=3.7 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
To fix error:
from urllib3.contrib import appengine as gaecontrib ImportError: cannot import name 'appengine' from 'urllib3.contrib' (/var/www/.local/lib/python3.10/site-packages/urllib3/contrib/__init__.py)